### PR TITLE
Revise filter interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Or we can filter a stream to create a new one that only contains events that
 satisfy a certain predicate:
 
 ```rust
-let negatives = stream.filter(|&x| x < 0).hold(0);
+let negatives = stream.filter_with(|&x| x < 0).hold(0);
 
 // This won't arrive at the cell.
 sink.send(4);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@
 //! # use carboxyl::Sink;
 //! # let sink = Sink::<i32>::new();
 //! # let stream = sink.stream();
-//! let negatives = stream.filter(|&x| x < 0).hold(0);
+//! let negatives = stream.filter_with(|&x| x < 0).hold(0);
 //!
 //! // This won't arrive at the cell.
 //! sink.send(4);


### PR DESCRIPTION
The basic `filter` primitive now maps a `Stream<Option<A>>` to a `Stream<A>`.
There is a new method `filter_with`, that captures the old behaviour.
