### PR TITLE
Properly order input events to snapshot

### DIFF
--- a/src/test_lib.rs
+++ b/src/test_lib.rs
@@ -195,3 +195,24 @@ fn bench_chain(b: &mut Bencher) {
         .hold(15);
     b.iter(|| sink.send(-5));
 }
+
+#[test]
+fn snapshot_order_standard() {
+    let sink = Sink::new();
+    let cell = sink.stream().hold(0);
+    let mut iter = cell.snapshot(&sink.stream()).iter();
+    sink.send(1);
+    assert_eq!(iter.next(), Some((0, 1)));
+}
+
+#[test]
+fn snapshot_order_alternative() {
+    let sink = Sink::new();
+    // Invert the "natural" order of the registry by declaring the stream before
+    // the cell, which are both used by the snapshot.
+    let first = sink.stream().map(|x| x);
+    let cell = sink.stream().hold(0);
+    let mut iter = cell.snapshot(&first).iter();
+    sink.send(1);
+    assert_eq!(iter.next(), Some((0, 1)));
+}

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -4,17 +4,49 @@
 //! locked, to ensure the atomicity of a transaction.
 
 use std::sync::{StaticMutex, MUTEX_INIT};
+use std::cell::RefCell;
 
 
 /// The global transaction lock.
 static TRANSACTION_MUTEX: StaticMutex = MUTEX_INIT;
 
 
+/// Registry for callbacks to be executed at the end of a transaction.
+thread_local!(
+    static FINAL_CALLBACKS: RefCell<Vec<Box<Fn() + 'static>>>
+        = RefCell::new(Vec::new())
+);
+
+
 /// Commit a transaction.
 ///
 /// Acquires the global lock and then executes the closure.
 pub fn commit<A, B, F: FnOnce(A) -> B>(args: A, transaction: F) -> B {
+    // Acquire lock
     let _lock = TRANSACTION_MUTEX.lock().ok()
         .expect("global transaction mutex poisoned");
-    transaction(args)
+    // Make sure there are no stale callbacks
+    FINAL_CALLBACKS.with(|store| {
+        if store.borrow().len() > 0 {
+            store.borrow_mut().clear();
+        }
+    });
+    // Perform the transaction
+    let result = transaction(args);
+    // Call all finalizers
+    FINAL_CALLBACKS.with(|store| {
+        for callback in store.borrow_mut().drain() {
+            callback();
+        }
+    });
+    // Return
+    result
+}
+
+
+/// Register a callback during a transaction.
+pub fn register_callback<F: Fn() + 'static>(callback: F) {
+    FINAL_CALLBACKS.with(move |store| {
+        store.borrow_mut().push(Box::new(callback))
+    });
 }


### PR DESCRIPTION
When `snapshot` receives updates both to its input cell and stream, the old cell value is used to generate the output event.

This is achieved by registering "finalizers" in a thread-local storage, to be called at the end of committing a transaction. When a cell update is received, snapshot does not update immediately but stores the new value in a temporary container, while retaining the current value first. At the end of the
transaction a finalizer updates the current value to the new one.

Fixes #16.
