### PR TITLE
Lifting of up to quaternary functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,14 +130,16 @@ extern crate log;
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread::Thread;
 use subject::{
-    Subject, Source, Mapper, WrapArc, Snapper, Merger, Filter, Holder, Lift2,
-    WeakSnapperWrapper, SamplingSubject, CellSwitcher, WeakLift2Wrapper,
-    ChannelBuffer, LoopCell, LoopCellEntry, Updates,
+    Subject, Source, Mapper, WrapArc, Snapper, Merger, Filter, Holder, Updates,
+    WeakSnapperWrapper, SamplingSubject, CellSwitcher, ChannelBuffer, LoopCell,
+    LoopCellEntry,
 };
 use transaction::commit;
+pub use lift::lift2;
 
 mod transaction;
 mod subject;
+mod lift;
 
 
 /// An event sink.
@@ -597,50 +599,6 @@ impl<A: Send + Sync + Clone> Cell<Cell<A>> {
             Cell { source: source.wrap_into_sampling_subject() }
         })
     }
-}
-
-
-/// Lift a two-argument function to a function on cells.
-///
-/// A lift maps a function on values to a function on cells. This particular
-/// function works only with a two-argument function and effectively turns two
-/// cells over types `A` and `B` into a cell over type `C`, given a function of
-/// type `F: Fn(A, B) -> C` by simply applying it two the inner values of the
-/// cells. So essentially `f(ba.sample(), bb.sample())` is the same as
-/// `lift2(f, ba, bb).sample()`.
-///
-/// The following example multiplies two behaviours:
-///
-/// ```
-/// # use carboxyl::{Sink, lift2};
-/// let sink_a = Sink::<i32>::new();
-/// let sink_b = Sink::<i32>::new();
-/// let product = lift2(
-///     |a, b| a * b,
-///     &sink_a.stream().hold(0),
-///     &sink_b.stream().hold(0)
-/// );
-/// assert_eq!(product.sample(), 0);
-/// sink_a.send(3);
-/// sink_b.send(5);
-/// assert_eq!(product.sample(), 15);
-/// ```
-pub fn lift2<A, B, C, F>(f: F, ba: &Cell<A>, bb: &Cell<B>) -> Cell<C>
-    where A: Send + Sync + Clone,
-          B: Send + Sync + Clone,
-          C: Send + Sync + Clone,
-          F: Fn(A, B) -> C + Send + Sync,
-{
-    commit((f, ba, bb), |(f, ba, bb)| {
-        let source = Arc::new(Mutex::new(Lift2::new(
-            (ba.sample_nocommit(), bb.sample_nocommit()), f, (ba.source.clone(), bb.source.clone())
-        )));
-        ba.source.lock().ok().expect("lift2 (ba)")
-            .listen(source.wrap_as_listener());
-        bb.source.lock().ok().expect("lift2 (bb)")
-            .listen(WeakLift2Wrapper::boxed(&source));
-        Cell { source: source.wrap_into_sampling_subject() }
-    })
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,6 @@
 //! functions to the FRP primitives, as they break the benefits you get from
 //! using FRP. (Except temporary print statements for debugging.)
 
-#![feature(unboxed_closures)]
 #![allow(unstable)]
 #![warn(missing_docs)]
 
@@ -135,11 +134,11 @@ use subject::{
     LoopCellEntry,
 };
 use transaction::commit;
-pub use lift::lift2;
 
 mod transaction;
 mod subject;
-mod lift;
+#[macro_use]
+pub mod lift;
 
 
 /// An event sink.

--- a/src/lift.rs
+++ b/src/lift.rs
@@ -1,63 +1,130 @@
+//! Lifting of n-ary functions.
+//!
+//! A lift maps a function on values to a function on cells. Given a function of
+//! type `F: Fn(A, B, …) -> R` and cells of types `Cell<A>, Cell<B>, …` the
+//! `lift!` macro creates a `Cell<R>`, whose content is computed using the
+//! function.
+//!
+//! Currently lift is only implemented for functions with up to four arguments.
+//! This limitation is due to the current implementation strategy (and maybe
+//! limitations of Rust's type system), but it can be increased to arbitrary but
+//! finite arity if required.
+//!
+//! # Example
+//!
+//! ```
+//! # #[macro_use] extern crate carboxyl;
+//! # fn main() {
+//! # use carboxyl::Sink;
+//! let sink_a = Sink::new();
+//! let sink_b = Sink::new();
+//! let product = lift!(
+//!     |a, b| a * b,
+//!     &sink_a.stream().hold(0),
+//!     &sink_b.stream().hold(0)
+//! );
+//! assert_eq!(product.sample(), 0);
+//! sink_a.send(3);
+//! sink_b.send(5);
+//! assert_eq!(product.sample(), 15);
+//! # }
+//! ```
+
 use std::sync::{Arc, Mutex};
 use subject::{Lift2, WeakLift2Wrapper, WrapArc};
 use transaction::commit;
-use Cell;
+use {Sink, Cell};
 
 
-/// Lift a two-argument function to a function on cells.
-///
-/// A lift maps a function on values to a function on cells. This particular
-/// function works only with a two-argument function and effectively turns two
-/// cells over types `A` and `B` into a cell over type `C`, given a function of
-/// type `F: Fn(A, B) -> C` by simply applying it two the inner values of the
-/// cells. So essentially `f(ba.sample(), bb.sample())` is the same as
-/// `lift2(f, ba, bb).sample()`.
-///
-/// The following example multiplies two behaviours:
-///
-/// ```
-/// # use carboxyl::{Sink, lift2};
-/// let sink_a = Sink::<i32>::new();
-/// let sink_b = Sink::<i32>::new();
-/// let product = lift2(
-///     |a, b| a * b,
-///     &sink_a.stream().hold(0),
-///     &sink_b.stream().hold(0)
-/// );
-/// assert_eq!(product.sample(), 0);
-/// sink_a.send(3);
-/// sink_b.send(5);
-/// assert_eq!(product.sample(), 15);
-/// ```
-pub fn lift2<A, B, C, F>(f: F, ba: &Cell<A>, bb: &Cell<B>) -> Cell<C>
-    where A: Send + Sync + Clone,
-          B: Send + Sync + Clone,
-          C: Send + Sync + Clone,
-          F: Fn(A, B) -> C + Send + Sync,
+#[macro_export]
+macro_rules! lift {
+    ($f: expr, $a: expr)
+        => ( $crate::lift::lift1($f, $a) );
+
+    ($f: expr, $a: expr, $b: expr)
+        => ( $crate::lift::lift2($f, $a, $b) );
+
+    ($f: expr, $a: expr, $b: expr, $c: expr)
+        => ( $crate::lift::lift3($f, $a, $b, $c) );
+
+    ($f: expr, $a: expr, $b: expr, $c: expr, $d: expr)
+        => ( $crate::lift::lift4($f, $a, $b, $c, $d) );
+}
+
+/// Lift a unary function.
+pub fn lift1<F, A, Ret>(f: F, ca: &Cell<A>) -> Cell<Ret>
+where F: Fn(A) -> Ret + Send + Sync,
+      A: Clone + Send + Sync,
+      Ret: Clone + Send + Sync,
 {
-    commit((f, ba, bb), |(f, ba, bb)| {
+    lift2(move |a, _| f(a), ca, &Sink::new().stream().hold(()))
+}
+
+/// Lift a binary function.
+pub fn lift2<F, A, B, Ret>(f: F, ca: &Cell<A>, cb: &Cell<B>) -> Cell<Ret>
+where F: Fn(A, B) -> Ret + Send + Sync,
+      A: Send + Sync + Clone,
+      B: Send + Sync + Clone,
+      Ret: Send + Sync + Clone,
+{
+    commit((f, ca, cb), |(f, ca, cb)| {
         let source = Arc::new(Mutex::new(Lift2::new(
-            (ba.sample_nocommit(), bb.sample_nocommit()), f, (ba.source.clone(), bb.source.clone())
+            (ca.sample_nocommit(), cb.sample_nocommit()), f, (ca.source.clone(), cb.source.clone())
         )));
-        ba.source.lock().ok().expect("lift2 (ba)")
+        ca.source.lock().ok().expect("lift2 (ca)")
             .listen(source.wrap_as_listener());
-        bb.source.lock().ok().expect("lift2 (bb)")
+        cb.source.lock().ok().expect("lift2 (cb)")
             .listen(WeakLift2Wrapper::boxed(&source));
         Cell { source: source.wrap_into_sampling_subject() }
     })
+}
+
+/// Lift a ternary function.
+pub fn lift3<F, A, B, C, Ret>(f: F, ca: &Cell<A>, cb: &Cell<B>, cc: &Cell<C>)
+    -> Cell<Ret>
+where F: Fn(A, B, C) -> Ret + Send + Sync,
+      A: Send + Sync + Clone,
+      B: Send + Sync + Clone,
+      C: Send + Sync + Clone,
+      Ret: Send + Sync + Clone,
+{
+    lift2(move |(a, b), c| f(a, b, c), &lift2(|a, b| (a, b), ca, cb), cc)
+}
+
+/// Lift a quarternary function.
+pub fn lift4<F, A, B, C, D, Ret>(f: F, ca: &Cell<A>, cb: &Cell<B>, cc: &Cell<C>, cd: &Cell<D>)
+    -> Cell<Ret>
+where F: Fn(A, B, C, D) -> Ret + Send + Sync,
+      A: Send + Sync + Clone,
+      B: Send + Sync + Clone,
+      C: Send + Sync + Clone,
+      D: Send + Sync + Clone,
+      Ret: Send + Sync + Clone,
+{
+    lift2(
+        move |(a, b), (c, d)| f(a, b, c, d),
+        &lift2(|a, b| (a, b), ca, cb),
+        &lift2(|c, d| (c, d), cc, cd)
+    )
 }
 
 
 #[cfg(test)]
 mod test {
     use Sink;
-    use super::*;
+
+    #[test]
+    fn lift1_test() {
+        let sink = Sink::new();
+        let lifted = lift!(|x| x + 2, &sink.stream().hold(3));
+        assert_eq!(lifted.sample(), 5);
+    }
 
     #[test]
     fn lift2_test() {
         let sink1 = Sink::new();
         let sink2 = Sink::new();
-        let lifted = lift2(|a, b| a + b, &sink1.stream().hold(0), &sink2.stream().hold(3));
+        let lifted = lift!(|a, b| a + b, &sink1.stream().hold(0), &sink2.stream().hold(3));
         assert_eq!(lifted.sample(), 3);
         sink1.send(1);
         assert_eq!(lifted.sample(), 4);
@@ -65,4 +132,30 @@ mod test {
         assert_eq!(lifted.sample(), 12);
     }
 
+    #[test]
+    fn lift3_test() {
+        let sink = Sink::new();
+        assert_eq!(
+            lift!(|x, y, z| x + 2 * y + z,
+                &sink.stream().hold(5),
+                &sink.stream().hold(3),
+                &sink.stream().hold(-4)
+            ).sample(),
+            7
+        );
+    }
+
+    #[test]
+    fn lift4_test() {
+        let sink = Sink::new();
+        assert_eq!(
+            lift!(|w, x, y, z| 4 * w + x + 2 * y + z,
+                &sink.stream().hold(-2),
+                &sink.stream().hold(5),
+                &sink.stream().hold(3),
+                &sink.stream().hold(-4)
+            ).sample(),
+            -1
+        );
+    }
 }

--- a/src/lift.rs
+++ b/src/lift.rs
@@ -1,0 +1,68 @@
+use std::sync::{Arc, Mutex};
+use subject::{Lift2, WeakLift2Wrapper, WrapArc};
+use transaction::commit;
+use Cell;
+
+
+/// Lift a two-argument function to a function on cells.
+///
+/// A lift maps a function on values to a function on cells. This particular
+/// function works only with a two-argument function and effectively turns two
+/// cells over types `A` and `B` into a cell over type `C`, given a function of
+/// type `F: Fn(A, B) -> C` by simply applying it two the inner values of the
+/// cells. So essentially `f(ba.sample(), bb.sample())` is the same as
+/// `lift2(f, ba, bb).sample()`.
+///
+/// The following example multiplies two behaviours:
+///
+/// ```
+/// # use carboxyl::{Sink, lift2};
+/// let sink_a = Sink::<i32>::new();
+/// let sink_b = Sink::<i32>::new();
+/// let product = lift2(
+///     |a, b| a * b,
+///     &sink_a.stream().hold(0),
+///     &sink_b.stream().hold(0)
+/// );
+/// assert_eq!(product.sample(), 0);
+/// sink_a.send(3);
+/// sink_b.send(5);
+/// assert_eq!(product.sample(), 15);
+/// ```
+pub fn lift2<A, B, C, F>(f: F, ba: &Cell<A>, bb: &Cell<B>) -> Cell<C>
+    where A: Send + Sync + Clone,
+          B: Send + Sync + Clone,
+          C: Send + Sync + Clone,
+          F: Fn(A, B) -> C + Send + Sync,
+{
+    commit((f, ba, bb), |(f, ba, bb)| {
+        let source = Arc::new(Mutex::new(Lift2::new(
+            (ba.sample_nocommit(), bb.sample_nocommit()), f, (ba.source.clone(), bb.source.clone())
+        )));
+        ba.source.lock().ok().expect("lift2 (ba)")
+            .listen(source.wrap_as_listener());
+        bb.source.lock().ok().expect("lift2 (bb)")
+            .listen(WeakLift2Wrapper::boxed(&source));
+        Cell { source: source.wrap_into_sampling_subject() }
+    })
+}
+
+
+#[cfg(test)]
+mod test {
+    use Sink;
+    use super::*;
+
+    #[test]
+    fn lift2_test() {
+        let sink1 = Sink::new();
+        let sink2 = Sink::new();
+        let lifted = lift2(|a, b| a + b, &sink1.stream().hold(0), &sink2.stream().hold(3));
+        assert_eq!(lifted.sample(), 3);
+        sink1.send(1);
+        assert_eq!(lifted.sample(), 4);
+        sink2.send(11);
+        assert_eq!(lifted.sample(), 12);
+    }
+
+}

--- a/src/test_lib.rs
+++ b/src/test_lib.rs
@@ -112,18 +112,6 @@ fn updates() {
 }
 
 #[test]
-fn lift2_test() {
-    let sink1 = Sink::new();
-    let sink2 = Sink::new();
-    let lifted = lift2(|a, b| a + b, &sink1.stream().hold(0), &sink2.stream().hold(3));
-    assert_eq!(lifted.sample(), 3);
-    sink1.send(1);
-    assert_eq!(lifted.sample(), 4);
-    sink2.send(11);
-    assert_eq!(lifted.sample(), 12);
-}
-
-#[test]
 fn switch() {
     let stream1 = Sink::<Option<i32>>::new();
     let stream2 = Sink::<Option<i32>>::new();


### PR DESCRIPTION
 This is a preliminary implementation to provide the practical functionality of n-ary lifting for the most common cases. The type system did not allow to implement this as a regular function/method without losing type inference. Therefore a new macro `lift!` was implemented to dispatch to the implementations for different arity.
### Breaking change
- `lift2` is no longer exported at the crate level, but in a module `lift`. It is recommended to use the macro `lift!` instead.
