### PR TITLE
Provide explicit forward-declaration of a cell

### DIFF
--- a/src/test_lib.rs
+++ b/src/test_lib.rs
@@ -219,10 +219,9 @@ fn snapshot_order_alternative() {
 fn cyclic_snapshot_accum() {
     let sink = Sink::new();
     let stream = sink.stream();
-    let accum: Cell<i32> = Cell::cyclic(0, |accum|
-        accum.snapshot(&stream)
-            .map(|(a, s)| a + s)
-    );
+    let accum = CellCycle::new(0);
+    let def = accum.snapshot(&stream).map(|(a, s)| a + s).hold(0);
+    let accum = accum.define(def);
     assert_eq!(accum.sample(), 0);
     sink.send(3);
     assert_eq!(accum.sample(), 3);


### PR DESCRIPTION
The CycleCell type can be declared without providing semantics. Subsequently it can be used as a cell, as it dereferences to a cell. A semantic definition can be provided later yielding a properly initialized cell.
