### PR TITLE
Fix to reflect Send loosing the 'static bound

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ impl<A> Clone for Sink<A> {
     }
 }
 
-impl<A: Send + Sync + Clone> Sink<A> {
+impl<A: Send + Sync + Clone + 'static> Sink<A> {
     /// Create a new sink.
     pub fn new() -> Sink<A> {
         Sink { source: Arc::new(Mutex::new(Source::new())) }
@@ -242,7 +242,7 @@ impl<A: Send + Sync + Clone> Sink<A> {
     /// This is the same as `feed`, but it does not block, since it spawns the
     /// feeding as a new task. This is useful, if the provided iterator is large
     /// or even infinite (e.g. an I/O event loop).
-    pub fn feed_async<I: Iterator<Item=A> + Send>(&self, iterator: I) {
+    pub fn feed_async<I: Iterator<Item=A> + Send + 'static>(&self, iterator: I) {
         let clone = self.clone();
         Thread::spawn(move || clone.feed(iterator));
     }
@@ -267,7 +267,7 @@ impl<A> Clone for Stream<A> {
     }    
 }
 
-impl<A: Send + Sync + Clone> Stream<A> {
+impl<A: Send + Sync + Clone + 'static> Stream<A> {
     /// A stream that never fires. This can be useful in certain situations,
     /// where a stream is logically required, but no events are expected.
     pub fn never() -> Stream<A> {
@@ -287,8 +287,8 @@ impl<A: Send + Sync + Clone> Stream<A> {
     /// assert_eq!(events.next(), Some(7));
     /// ```
     pub fn map<B, F>(&self, f: F) -> Stream<B>
-        where B: Send + Sync + Clone,
-              F: Fn(A) -> B + Send + Sync,
+        where B: Send + Sync + Clone + 'static,
+              F: Fn(A) -> B + Send + Sync + 'static,
     {
         let source = Arc::new(Mutex::new(Mapper::new(f, self.source.clone())));
         commit((), |_| {
@@ -314,7 +314,7 @@ impl<A: Send + Sync + Clone> Stream<A> {
     /// assert_eq!(events.next(), Some(5));
     /// ```
     pub fn filter<F>(&self, f: F) -> Stream<A>
-        where F: Fn(&A) -> bool + Send + Sync,
+        where F: Fn(&A) -> bool + Send + Sync + 'static,
     {
         self.filter_map(move |a| if f(&a) { Some(a) } else { None })
     }
@@ -334,8 +334,8 @@ impl<A: Send + Sync + Clone> Stream<A> {
     /// assert_eq!(events.next(), Some(6));
     /// ```
     pub fn filter_map<B, F>(&self, f: F) -> Stream<B>
-        where B: Send + Sync + Clone,
-              F: Fn(A) -> Option<B> + Send + Sync,
+        where B: Send + Sync + Clone + 'static,
+              F: Fn(A) -> Option<B> + Send + Sync + 'static,
     {
         self.map(f).filter_just()
     }
@@ -411,8 +411,8 @@ impl<A: Send + Sync + Clone> Stream<A> {
     /// sink.send(4);
     /// assert_eq!(sum.sample(), 6);
     pub fn scan<B, F>(&self, initial: B, f: F) -> Cell<B>
-        where B: Send + Sync + Clone,
-              F: Fn(B, A) -> B + Send + Sync,
+        where B: Send + Sync + Clone + 'static,
+              F: Fn(B, A) -> B + Send + Sync + 'static,
     {
         let scan = CellCycle::new(initial.clone());
         let def = scan.snapshot(self).map(move |(a, b)| f(a, b)).hold(initial);
@@ -420,7 +420,7 @@ impl<A: Send + Sync + Clone> Stream<A> {
     }
 }
 
-impl<A: Send + Sync + Clone> Stream<Option<A>> {
+impl<A: Send + Sync + Clone + 'static> Stream<Option<A>> {
     /// Filter a stream of options.
     ///
     /// `filter_just` creates a new stream that only fires the unwrapped
@@ -456,7 +456,7 @@ impl<A> Clone for Cell<A> {
     }
 }
 
-impl<A: Send + Sync + Clone> Cell<A> {
+impl<A: Send + Sync + Clone + 'static> Cell<A> {
     /// Sample the current value of the cell.
     ///
     /// `sample` provides access to the underlying data of a cell.
@@ -489,7 +489,7 @@ impl<A: Send + Sync + Clone> Cell<A> {
     /// sink2.send(3.0);
     /// assert_eq!(events.next(), Some((4, 3.0)));
     /// ```
-    pub fn snapshot<B: Send + Sync + Clone>(&self, event: &Stream<B>) -> Stream<(A, B)> {
+    pub fn snapshot<B: Send + Sync + Clone + 'static>(&self, event: &Stream<B>) -> Stream<(A, B)> {
         commit((), |_| {
             let source = Arc::new(Mutex::new(Snapper::new(
                 self.sample_nocommit(), (self.source.clone(), event.source.clone())
@@ -514,7 +514,7 @@ impl<A: Send + Sync + Clone> Cell<A> {
 
 }
 
-impl<A: Send + Sync + Clone> Cell<Cell<A>> {
+impl<A: Send + Sync + Clone + 'static> Cell<Cell<A>> {
     /// Switch between cells.
     ///
     /// This transforms a `Cell<Cell<A>>` into a `Cell<A>`. The nested cell can
@@ -611,7 +611,7 @@ pub struct CellCycle<A> {
     cell: Cell<A>,
 }
 
-impl<A: Clone + Send + Sync> CellCycle<A> {
+impl<A: Clone + Send + Sync + 'static> CellCycle<A> {
     /// Predeclare a cell
     ///
     /// FIXME: the `initial` parameter is unfortunately necessary due to a lack
@@ -663,7 +663,7 @@ pub struct Events<A> {
     buffer: Arc<Mutex<ChannelBuffer<A>>>,
 }
 
-impl<A: Send + Sync + Clone> Events<A> {
+impl<A: Send + Sync + Clone + 'static> Events<A> {
     fn new(event: &Stream<A>) -> Events<A> {
         let (tx, rx) = mpsc::channel();
         let chanbuf = Arc::new(Mutex::new(ChannelBuffer::new(
@@ -675,7 +675,7 @@ impl<A: Send + Sync + Clone> Events<A> {
     }
 }
 
-impl<A: Send + Sync> Iterator for Events<A> {
+impl<A: Send + Sync + 'static> Iterator for Events<A> {
     type Item = A;
     fn next(&mut self) -> Option<A> { self.receiver.recv().ok() }
 }

--- a/src/lift.rs
+++ b/src/lift.rs
@@ -53,19 +53,19 @@ macro_rules! lift {
 
 /// Lift a unary function.
 pub fn lift1<F, A, Ret>(f: F, ca: &Cell<A>) -> Cell<Ret>
-where F: Fn(A) -> Ret + Send + Sync,
-      A: Clone + Send + Sync,
-      Ret: Clone + Send + Sync,
+where F: Fn(A) -> Ret + Send + Sync + 'static,
+      A: Clone + Send + Sync + 'static,
+      Ret: Clone + Send + Sync + 'static,
 {
     lift2(move |a, _| f(a), ca, &Sink::new().stream().hold(()))
 }
 
 /// Lift a binary function.
 pub fn lift2<F, A, B, Ret>(f: F, ca: &Cell<A>, cb: &Cell<B>) -> Cell<Ret>
-where F: Fn(A, B) -> Ret + Send + Sync,
-      A: Send + Sync + Clone,
-      B: Send + Sync + Clone,
-      Ret: Send + Sync + Clone,
+where F: Fn(A, B) -> Ret + Send + Sync + 'static,
+      A: Send + Sync + Clone + 'static,
+      B: Send + Sync + Clone + 'static,
+      Ret: Send + Sync + Clone + 'static,
 {
     commit((f, ca, cb), |(f, ca, cb)| {
         let source = Arc::new(Mutex::new(Lift2::new(
@@ -82,11 +82,11 @@ where F: Fn(A, B) -> Ret + Send + Sync,
 /// Lift a ternary function.
 pub fn lift3<F, A, B, C, Ret>(f: F, ca: &Cell<A>, cb: &Cell<B>, cc: &Cell<C>)
     -> Cell<Ret>
-where F: Fn(A, B, C) -> Ret + Send + Sync,
-      A: Send + Sync + Clone,
-      B: Send + Sync + Clone,
-      C: Send + Sync + Clone,
-      Ret: Send + Sync + Clone,
+where F: Fn(A, B, C) -> Ret + Send + Sync + 'static,
+      A: Send + Sync + Clone + 'static,
+      B: Send + Sync + Clone + 'static,
+      C: Send + Sync + Clone + 'static,
+      Ret: Send + Sync + Clone + 'static,
 {
     lift2(move |(a, b), c| f(a, b, c), &lift2(|a, b| (a, b), ca, cb), cc)
 }
@@ -94,12 +94,12 @@ where F: Fn(A, B, C) -> Ret + Send + Sync,
 /// Lift a quarternary function.
 pub fn lift4<F, A, B, C, D, Ret>(f: F, ca: &Cell<A>, cb: &Cell<B>, cc: &Cell<C>, cd: &Cell<D>)
     -> Cell<Ret>
-where F: Fn(A, B, C, D) -> Ret + Send + Sync,
-      A: Send + Sync + Clone,
-      B: Send + Sync + Clone,
-      C: Send + Sync + Clone,
-      D: Send + Sync + Clone,
-      Ret: Send + Sync + Clone,
+where F: Fn(A, B, C, D) -> Ret + Send + Sync + 'static,
+      A: Send + Sync + Clone + 'static,
+      B: Send + Sync + Clone + 'static,
+      C: Send + Sync + Clone + 'static,
+      D: Send + Sync + Clone + 'static,
+      Ret: Send + Sync + Clone + 'static,
 {
     lift2(
         move |(a, b), (c, d)| f(a, b, c, d),


### PR DESCRIPTION
There is still a compiling error with 'cargo test':

src\transaction.rs:130:44: 130:48 error: type `()` does not implement any method in scope named `ok`
src\transaction.rs:130         for guard in guards { guard.join().ok().expect("thread failed"); }
