### PR TITLE
Fix to latest nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["frp", "reactive", "event", "concurrency"]
 license = "LGPL-3.0+"
 
 [dev-dependencies]
-rand = "0.1"
+rand = "*"

--- a/src/subject.rs
+++ b/src/subject.rs
@@ -47,8 +47,8 @@ impl<A, L> Listener<A> for WeakListenerWrapper<L>
 }
 
 
-type KeepAlive<A> = Arc<Mutex<Box<Subject<A> + 'static>>>;
-type KeepAliveSample<A> = Arc<Mutex<Box<SamplingSubject<A> + 'static>>>;
+pub type KeepAlive<A> = Arc<Mutex<Box<Subject<A> + 'static>>>;
+pub type KeepAliveSample<A> = Arc<Mutex<Box<SamplingSubject<A> + 'static>>>;
 
 
 pub struct StrongSubjectWrapper<S> {


### PR DESCRIPTION
Switch to use the most recent version of the rand crate, as 0.1.\* is no longer
kept up-to-date with the compiler. Also, the KeepAlive[Sample] type aliases had
to be reexported publicly from the subject module.
