### PR TITLE
Limit usage of test-only unstable features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,8 @@
 //! functions to the FRP primitives, as they break the benefits you get from
 //! using FRP. (Except temporary print statements for debugging.)
 
-#![feature(alloc, std_misc, test, thread_sleep)]
+#![feature(alloc, std_misc)]
+#![cfg_attr(test, feature(test, thread_sleep))]
 #![warn(missing_docs)]
 
 #[cfg(test)]


### PR DESCRIPTION
They are only needed in the test suite, after all.
