### PR TITLE
Use lazy_static! macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,8 @@ readme = "README.md"
 keywords = ["frp", "reactive", "event", "concurrency"]
 license = "LGPL-3.0+"
 
+[dependencies]
+lazy_static = "0.1.10"
+
 [dev-dependencies]
 rand = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,12 +118,14 @@
 //! functions to the FRP primitives, as they break the benefits you get from
 //! using FRP. (Except temporary print statements for debugging.)
 
-#![feature(alloc, std_misc)]
+#![feature(alloc)]
 #![cfg_attr(test, feature(test))]
 #![warn(missing_docs)]
 
 #[cfg(test)]
 extern crate test;
+#[macro_use(lazy_static)]
+extern crate lazy_static;
 
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;


### PR DESCRIPTION
This is an external crate independent of the standard library. Should be
replaced by a regular static mutex, as soon as that is stabilized in the
standard library.
