### PR TITLE
Cache return value of a signal function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,8 @@
 
 #[cfg(test)]
 extern crate test;
+#[cfg(test)]
+extern crate rand;
 #[macro_use(lazy_static)]
 extern crate lazy_static;
 

--- a/src/lift.rs
+++ b/src/lift.rs
@@ -239,4 +239,16 @@ mod test {
             -1
         );
     }
+
+    #[test]
+    fn lift0_equal_within_transaction() {
+        use rand::random;
+        // Generate a completely random signal
+        let rnd = lift!(random::<i64>);
+        // Make a tuple with itself
+        let gather = lift!(|a, b| (a, b), &rnd, &rnd);
+        // Both components should be equal
+        let (a, b) = gather.sample();
+        assert_eq!(a, b);
+    }
 }


### PR DESCRIPTION
Within a transaction, a signal should yield the same value, no matter how often
it is sampled for various reasons. For functions with side-effects (e.g. random
number generation, system time) one cannot guarantee that they return the same
value. Therefore the result of the function is cached for the duration of a
transaction. The cache is reset at the end of the transaction, so that the
signal function may return a different value later.
