### PR TITLE
Hide away SignalCycle

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ extern crate quickcheck;
 extern crate lazy_static;
 
 pub use stream::{ Sink, Stream };
-pub use signal::{ Signal, SignalMut, SignalCycle };
+pub use signal::{ Signal, SignalMut };
 
 mod transaction;
 mod source;


### PR DESCRIPTION
For the current API to work, there is no need to expose SignalCycle. This is
especially true, as it is only required to auto-deref to a signal. To simplify
the API, it is made private by this commit.
