### PR TITLE
Modify #![feature(...)] declaration, for newest Rust nightly.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@
 //! the FRP primitives, as they break the benefits you get from using FRP.
 //! (An exception here is debugging output.)
 
-#![feature(core, alloc)]
+#![feature(arc_weak, fnbox)]
 #![cfg_attr(test, feature(test, scoped))]
 #![warn(missing_docs)]
 


### PR DESCRIPTION
It didn't compile without this modification on `rustc 1.3.0-nightly (e5a28bca7 2015-06-25)`.

Core and alloc gave warnings about not being recognized,
so I removed them.
