### PR TITLE
Move to stable Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ script:
     cargo --version
     travis-cargo build &&
     travis-cargo test &&
-    travis-cargo bench &&
     travis-cargo doc
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rust:
 
 before_script:
   - |
-    pip install 'travis-cargo==0.1.2' --user &&
+    pip install 'travis-cargo==0.1.8' --user &&
     export PATH=$HOME/.local/bin:$PATH
 
 script:

--- a/src/fnbox.rs
+++ b/src/fnbox.rs
@@ -1,0 +1,13 @@
+//! FnBox replacement
+
+/// Specialized replacement for unstable FnBox from stdlib
+pub trait FnBox {
+    /// Call a boxed closure
+    fn call_box(self: Box<Self>);
+}
+
+impl<F: FnOnce()> FnBox for F {
+    fn call_box(self: Box<Self>) {
+        self();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@
 //! the FRP primitives, as they break the benefits you get from using FRP.
 //! (An exception here is debugging output.)
 
-#![feature(arc_weak, fnbox)]
+#![feature(fnbox)]
 #![cfg_attr(test, feature(test))]
 #![warn(missing_docs)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,6 @@
 //! the FRP primitives, as they break the benefits you get from using FRP.
 //! (An exception here is debugging output.)
 
-#![feature(fnbox)]
 #![cfg_attr(test, feature(test))]
 #![warn(missing_docs)]
 
@@ -155,6 +154,7 @@ mod pending;
 mod readonly;
 mod stream;
 mod signal;
+mod fnbox;
 #[macro_use]
 pub mod lift;
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,11 +133,8 @@
 //! the FRP primitives, as they break the benefits you get from using FRP.
 //! (An exception here is debugging output.)
 
-#![cfg_attr(test, feature(test))]
 #![warn(missing_docs)]
 
-#[cfg(test)]
-extern crate test;
 #[cfg(test)]
 extern crate rand;
 #[cfg(test)]

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Mutex;
 use std::cell::RefCell;
-use std::boxed::FnBox;
+use ::fnbox::FnBox;
 
 
 /// The global transaction lock.
@@ -24,7 +24,7 @@ thread_local!(
 
 
 /// A callback.
-type Callback = Box<FnBox() + 'static>;
+type Callback = Box<FnBox + 'static>;
 
 
 /// A transaction.
@@ -66,7 +66,7 @@ impl Transaction {
     /// Finalize the transaction
     fn finalize(self) {
         for finalizer in self.finalizers {
-            finalizer.call_box(());
+            finalizer.call_box();
         }
     }
 }
@@ -99,7 +99,7 @@ pub fn commit<A, F: FnOnce() -> A>(body: F) -> A {
         let callbacks = with_current(Transaction::advance);
         if callbacks.is_empty() { break }
         for callback in callbacks {
-            callback.call_box(());
+            callback.call_box();
         }
     }
     // Call all finalizers and drop the transaction


### PR DESCRIPTION
Removes usage of experimental features `arc_weak`, `fnbox` and `test` in `src/` directory.
Benchmarks still use `test`.
