### PR TITLE
Remove derivation of Show trait from test, as this seems not to be stable yet.

### DIFF
--- a/src/signal.rs
+++ b/src/signal.rs
@@ -260,7 +260,7 @@ impl<A: Clone + Send + Sync + 'static> Signal<Signal<A>> {
     /// ```
     /// # use carboxyl::Sink;
     /// // Button type
-    /// #[derive(Clone, Show)]
+    /// #[derive(Clone)]
     /// enum Button { A, B };
     ///
     /// // The input sinks


### PR DESCRIPTION
```
    <anon>:5:21: 5:25 error: `#[derive]` for custom traits is not stable enough for use and is subject to change
<anon>:5     #[derive(Clone, Show)]
                             ^~~~
<anon>:5:21: 5:25 help: add #![feature(custom_derive)] to the crate attributes to enable
error: aborting due to previous error


failures:
    signal::switch_0
```
