### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/aepsil0n/carboxyl.png?label=ready&title=Ready)](https://waffle.io/aepsil0n/carboxyl)
 [![Build Status](https://img.shields.io/travis/aepsil0n/carboxyl.svg)](https://travis-ci.org/aepsil0n/carboxyl)
 [![](https://img.shields.io/crates/v/carboxyl.svg)](https://crates.io/crates/carboxyl)
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/aepsil0n/carboxyl

This was requested by a real person (user aepsil0n) on waffle.io, we're not trying to spam you.
