### PR TITLE
Add skeptic to test examples in Readme.md

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.rs]
+indent_style = space
+indent_size = 4
+
+[*.toml]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/aepsil0n/carboxyl"
 readme = "README.md"
 keywords = ["frp", "reactive", "event", "concurrency"]
 license = "LGPL-3.0+"
+build = "build.rs"
 
 [dependencies]
 lazy_static = "0.1"
@@ -16,3 +17,7 @@ lazy_static = "0.1"
 [dev-dependencies]
 rand = "0.3"
 quickcheck = "0.2"
+skeptic = "0.1"
+
+[build-dependencies]
+skeptic = "0.1"

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ create a *stream* of events. Streams can also be filtered, mapped and merged. A
 hold the last event from a stream in a signal.
 
 ```rust
-use carboxyl::Sink;
+extern crate carboxyl;
 
-let sink = Sink::new();
+let sink = carboxyl::Sink::new();
 let stream = sink.stream();
 let signal = stream.hold(3);
 
@@ -38,15 +38,23 @@ One can also directly iterate over the stream instead of holding it in a
 signal:
 
 ```rust
+extern crate carboxyl;
+let sink = carboxyl::Sink::new();
+let stream = sink.stream();
+
 let mut events = stream.events();
 sink.send(4);
 assert_eq!(events.next(), Some(4));
 ```
 
-Streams and signals can be combined using various primitives. We can map a stream
-to another stream using a function:
+Streams and signals can be combined using various primitives. We can map a
+stream to another stream using a function:
 
 ```rust
+extern crate carboxyl;
+let sink = carboxyl::Sink::new();
+let stream = sink.stream();
+
 let squares = stream.map(|x| x * x).hold(0);
 sink.send(4);
 assert_eq!(squares.sample(), 16);
@@ -56,6 +64,10 @@ Or we can filter a stream to create a new one that only contains events that
 satisfy a certain predicate:
 
 ```rust
+extern crate carboxyl;
+let sink = carboxyl::Sink::new();
+let stream = sink.stream();
+
 let negatives = stream.filter(|&x| x < 0).hold(0);
 
 // This won't arrive at the signal.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+extern crate skeptic;
+
+fn main() {
+    skeptic::generate_doc_tests(&["README.md"]);
+}

--- a/tests/skeptic.rs
+++ b/tests/skeptic.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));


### PR DESCRIPTION
Fixes #44.

This also includes a commit adding an `.editorconfig` file. Feel free to ignore this.
