### PR TITLE
Fix private_in_public warnings

### DIFF
--- a/src/signal.rs
+++ b/src/signal.rs
@@ -16,7 +16,7 @@ use testing::ArcFn;
 
 
 /// A functional signal. Caches its return value during a transaction.
-struct FuncSignal<A> {
+pub struct FuncSignal<A> {
     func: Box<Fn() -> A + Send + Sync + 'static>,
     cache: Arc<Mutex<Option<A>>>,
 }


### PR DESCRIPTION
This fixes the "warning: private type in public interface" warnings. Rustc tells us that "this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!".

Please note that this means that the `FuncSignal` struct (but not its members will be public).
